### PR TITLE
Rename investment phase to stage

### DIFF
--- a/generator/specs/definitions/investment_defs.yml
+++ b/generator/specs/definitions/investment_defs.yml
@@ -72,8 +72,8 @@
         example: 'Company has asked us to keep project quiet until official announcement'
       operations_commenced_documents:
         $ref: '#/definitions/Documents'
-      phase:
-        $ref: '#/definitions/Phase'
+      stage:
+        $ref: '#/definitions/Stage'
       project_code:
         type: string
         example: 'P-01234567'
@@ -95,6 +95,7 @@
       value_complete:
         type: boolean
         example: false
+        description: Whether the value section is complete enough to move to the next project stage
       total_investment:
         type: integer
         example: 145000000
@@ -160,6 +161,7 @@
       requirements_complete:
         type: boolean
         example: false
+        description: Whether the requirements section is complete enough to move to the next project stage
       client_requirements:
         type: string
         example: 'Marriott are looking to expand into a city or town where they do not currently have a presence, or have room for expansion....'
@@ -225,6 +227,10 @@
         $ref: '#/definitions/AdviserTeam'
       project_assurance_advisor:
         $ref: '#/definitions/Adviser'
+      team_complete:
+        type: boolean
+        example: false
+        description: Whether the team section is complete enough to move to the next project stage
   BusinessActivity:
     type: object
     required:
@@ -317,9 +323,9 @@
       name:
         type: string
         example: 'Sector Advisory Services'
-  Phase:
+  Stage:
     type: object
-    description: 'Project phase metadata'
+    description: 'Project stage metadata'
     required:
     - id
     - name

--- a/generator/specs/definitions/search_defs.yml
+++ b/generator/specs/definitions/search_defs.yml
@@ -191,7 +191,7 @@
         type: string
         format: uuid
         example: 'd290f1ee-6c54-4b01-90e6-d701748f0851'
-      phase:
+      stage:
         type: string
         format: uuid
         example: 'd290f1ee-6c54-4b01-90e6-d701748f0851'


### PR DESCRIPTION
Phase will still work (for now) in the investment endpoints for backwards compatibility.