### PR TITLE
Add contact and audit endpoints

### DIFF
--- a/generator/specs/definitions/audit_defs.yml
+++ b/generator/specs/definitions/audit_defs.yml
@@ -12,6 +12,9 @@
     type: object
     description: An audit log entry containing changes made to an object
     properties:
+      id:
+        type: integer
+        example: 70
       user:
         $ref: '#/definitions/Adviser'
       timestamp:

--- a/generator/specs/definitions/audit_defs.yml
+++ b/generator/specs/definitions/audit_defs.yml
@@ -1,0 +1,36 @@
+  AuditItemList:
+    type: object
+    description: A list of audit log entries, representing historical changes made to the referenced object
+    required:
+    - results
+    properties:
+      results:
+        type: array
+        items:
+          $ref: '#/definitions/AuditItem'
+  AuditItem:
+    type: object
+    description: An audit log entry containing changes made to an object
+    properties:
+      user:
+        $ref: '#/definitions/Adviser'
+      timestamp:
+        type: string
+        format: date-time
+        example: 2017-08-18T13:42:08.134932
+      comment:
+        type: string
+        description: Only used for changes made via admin pages
+        example: Changed telephone_number.
+      changes:
+        type: object
+        description: Mapping of changes with changed field names as keys
+        additionalProperties:
+          type: array
+          description: 'Array with exactly two items: [old value, new value]'
+          minItems: 2
+          maxItems: 2
+          items:
+            # JSON Schema supports items as an array, but this doesn't seem to work with OpenAPI 2.0
+            type: string
+            example: John

--- a/generator/specs/definitions/company_defs.yml
+++ b/generator/specs/definitions/company_defs.yml
@@ -175,117 +175,6 @@
       name:
         type: string
         example: 'Company Registered Name Ltd'
-  ContactArray:
-    type: array
-    items:
-      $ref: '#/definitions/Contact'
-  Contact:
-    type: object
-    required:
-      - id
-      - first_name
-      - last_name
-    properties:
-      id:
-        type: string
-        format: uuid
-        example: 'd290f1ee-6c54-4b01-90e6-d701748f0851'
-      first_name:
-        type: string
-        example: 'Alison'
-      last_name:
-        type: string
-        example: 'Contact'
-      archived:
-        type: boolean
-      archived_on:
-        format: date-time
-        example: 2014-07-23T10:36:04
-      archived_reason:
-        type: string
-        example: 'Archived Reason'
-      created_on:
-        format: date-time
-        example: 2014-07-23T10:36:04
-      modified_on:
-        format: date-time
-        example: 2014-07-23T10:36:04
-      title:
-        $ref: '#/definitions/ContactTitle'
-      primary:
-        type: boolean
-      telephone_countrycode:
-        type: string
-        example: '+44'
-      telephone_number:
-        type: string
-        example: '12345678'
-      email:
-        type: string
-        example: 'valid@email.address'
-      address_same_as_company:
-        type: boolean
-      address_1:
-        type: string
-        example: '1 Woodlane'
-      address_2:
-        type: string
-        example: '1 Woodlane'
-      address_3:
-        type: string
-        example: '1 Woodlane'
-      address_4:
-        type: string
-        example: '1 Woodlane'
-      address_town:
-        type: string
-        example: 'London'
-      address_county:
-        type: string
-        example: 'County'
-      address_postcode:
-        type: string
-        example: 'ABC 123'
-      telephone_alternative:
-        type: string
-        example: 'Telegraph'
-      email_alternative:
-        type: string
-        example: 'alternative@email.address'
-      notes:
-        type: string
-        example: 'Notes'
-      job_title:
-        type: string
-        example: 'Director'
-      contactable_by_dit:
-        type: boolean
-      contactable_by_dit_partners:
-        type: boolean
-      contactable_by_email:
-        type: boolean
-      contactable_by_phone:
-        type: boolean
-      address_country:
-        $ref: '#/definitions/Country'
-      advisor:
-        $ref: '#/definitions/Adviser'
-      archived_by:
-        $ref: '#/definitions/Adviser'
-      company:
-        $ref: '#/definitions/CompanySlim'
-  ContactSlim:
-    type: object
-    required:
-    - id
-    properties:
-      id:
-        type: string
-        format: uuid
-        example: 'd290f1ee-6c54-4b01-90e6-d701748f0851'
-      name:
-        type: string
-        example: George Theo
   CountryArray:
     type: array
     items:
@@ -345,19 +234,6 @@
       name:
         type: string
         example: 'HeadquarterType'
-  ContactTitle:
-    type: object
-    description: "Title of the contact"
-    required:
-    - id
-    - name
-    properties:
-      id:
-        type: string
-        format: uuid
-      name:
-        type: string
-        example: 'Mr.'
   TeamSlim:
     type: object
     required:

--- a/generator/specs/definitions/contact_defs.yml
+++ b/generator/specs/definitions/contact_defs.yml
@@ -50,12 +50,6 @@
       address_2:
         type: string
         example: '1 Woodlane'
-      address_3:
-        type: string
-        example: '1 Woodlane'
-      address_4:
-        type: string
-        example: '1 Woodlane'
       address_town:
         type: string
         example: 'London'

--- a/generator/specs/definitions/contact_defs.yml
+++ b/generator/specs/definitions/contact_defs.yml
@@ -97,6 +97,17 @@
     type: array
     items:
       $ref: '#/definitions/Contact'
+  ContactList:
+    type: object
+    required:
+    - count
+    - results
+    properties:
+      count:
+        type: integer
+        example: 30
+      results:
+        $ref: '#/definitions/ContactArray'
   ContactSlim:
     type: object
     required:

--- a/generator/specs/definitions/contact_defs.yml
+++ b/generator/specs/definitions/contact_defs.yml
@@ -1,0 +1,124 @@
+  Contact:
+    type: object
+    required:
+      - id
+      - first_name
+      - last_name
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: 'd290f1ee-6c54-4b01-90e6-d701748f0851'
+      first_name:
+        type: string
+        example: 'Alison'
+      last_name:
+        type: string
+        example: 'Contact'
+      archived:
+        type: boolean
+      archived_on:
+        format: date-time
+        example: 2014-07-23T10:36:04
+      archived_reason:
+        type: string
+        example: 'Archived Reason'
+      created_on:
+        format: date-time
+        example: 2014-07-23T10:36:04
+      modified_on:
+        format: date-time
+        example: 2014-07-23T10:36:04
+      title:
+        $ref: '#/definitions/ContactTitle'
+      primary:
+        type: boolean
+      telephone_countrycode:
+        type: string
+        example: '+44'
+      telephone_number:
+        type: string
+        example: '12345678'
+      email:
+        type: string
+        example: 'valid@email.address'
+      address_same_as_company:
+        type: boolean
+      address_1:
+        type: string
+        example: '1 Woodlane'
+      address_2:
+        type: string
+        example: '1 Woodlane'
+      address_3:
+        type: string
+        example: '1 Woodlane'
+      address_4:
+        type: string
+        example: '1 Woodlane'
+      address_town:
+        type: string
+        example: 'London'
+      address_county:
+        type: string
+        example: 'County'
+      address_postcode:
+        type: string
+        example: 'ABC 123'
+      telephone_alternative:
+        type: string
+        example: 'Telegraph'
+      email_alternative:
+        type: string
+        example: 'alternative@email.address'
+      notes:
+        type: string
+        example: 'Notes'
+      job_title:
+        type: string
+        example: 'Director'
+      contactable_by_dit:
+        type: boolean
+      contactable_by_dit_partners:
+        type: boolean
+      contactable_by_email:
+        type: boolean
+      contactable_by_phone:
+        type: boolean
+      address_country:
+        $ref: '#/definitions/Country'
+      adviser:
+        $ref: '#/definitions/Adviser'
+      archived_by:
+        $ref: '#/definitions/Adviser'
+      company:
+        $ref: '#/definitions/CompanySlim'
+  ContactArray:
+    type: array
+    items:
+      $ref: '#/definitions/Contact'
+  ContactSlim:
+    type: object
+    required:
+    - id
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: 'd290f1ee-6c54-4b01-90e6-d701748f0851'
+      name:
+        type: string
+        example: George Theo
+  ContactTitle:
+    type: object
+    description: "Title of the contact"
+    required:
+    - id
+    - name
+    properties:
+      id:
+        type: string
+        format: uuid
+      name:
+        type: string
+        example: 'Mr'

--- a/generator/specs/paths/company.yml
+++ b/generator/specs/paths/company.yml
@@ -46,11 +46,6 @@
         required: true
         schema:
           $ref: '#/definitions/Company'
-      - in: query
-        name: Archived
-        description: Update the company's status to Archived
-        required: false
-        type: boolean
       responses:
         200:
           description: item updated

--- a/generator/specs/paths/company.yml
+++ b/generator/specs/paths/company.yml
@@ -56,6 +56,30 @@
           description: item updated
         400:
           description: invalid input, object invalid
+  /v3/company/{companyId}/audit:
+    get:
+      tags:
+      - company
+      summary: Get audit log
+      operationId: getCompanyAudit
+      description: |
+        Returns the audit log for a specified company
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: companyId
+        description: UUID for a Data Hub company
+        required: true
+        type: string
+        format: uuid
+      responses:
+        200:
+          description: JSON API formatted company object
+          schema:
+            $ref: '#/definitions/AuditItemList'
+        404:
+          description: company does not exist
   /v3/company/{company_id}/archive:
     post:
       tags:

--- a/generator/specs/paths/contact.yml
+++ b/generator/specs/paths/contact.yml
@@ -1,0 +1,188 @@
+  /v3/contact:
+    get:
+      tags:
+      - contact
+      summary: Gets a list of contacts in the system
+      operationId: getAllContacts
+      description: Gets a list of contacts, optionally filtered by company
+      produces:
+      - application/json
+      parameters:
+      - in: query
+        name: company_id
+        description: UUID of a company to filter results by
+        default: 'd290f1ee-6c54-4b01-90e6-d701748f0851'
+        required: false
+        type: string
+        format: uuid
+      - in: query
+        name: offset
+        type: integer
+        description: Pagination parameter
+        required: false
+      - in: query
+        name: limit
+        type: integer
+        description: Pagination parameter
+        required: false
+      responses:
+        200:
+          description: Single page of results
+          schema:
+            $ref: '#/definitions/ContactList'
+        400:
+          description: bad input parameter
+    post:
+      tags:
+      - contact
+      summary: Creates a contact
+      operationId: createContact
+      description: Adds a Data Hub contact from a Companies House contact
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - in: body
+        name: contact
+        description: Contact to add
+        required: true
+        schema:
+          $ref: '#/definitions/Contact'
+      responses:
+        201:
+          description: item created
+        400:
+          description: invalid input, object invalid
+        409:
+          description: contact already exists
+  /v3/contact/{contactId}:
+    get:
+      tags:
+      - contact
+      summary: Gets a single contact
+      operationId: getContact
+      description: |
+        Passing in a contact UUID returns a Data Hub contact object
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: contactId
+        description: UUID for a Data Hub contact
+        required: true
+        type: string
+        format: uuid
+      responses:
+        200:
+          description: JSON contact object
+          schema:
+            $ref: '#/definitions/Contact'
+        400:
+          description: bad input parameter
+        404:
+          description: contact does not exist
+    patch:
+      tags:
+      - contact
+      summary: Updates a contact
+      operationId: updateContact
+      description: Updates an existing contact, changing only the fields specified in the request
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: contactId
+        description: UUID for a Data Hub contact
+        type: string
+        required: true
+      - in: body
+        name: contact
+        description: Contact data to update
+        required: true
+        schema:
+          $ref: '#/definitions/Contact'
+      responses:
+        200:
+          description: item updated
+        400:
+          description: invalid input, object invalid
+  /v3/contact/{contactId}/audit:
+    get:
+      tags:
+      - contact
+      summary: Get audit log for a contact
+      operationId: getContactAudit
+      description: |
+        Returns the audit log for a specified contact
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: contactId
+        description: UUID for a Data Hub contact
+        required: true
+        type: string
+        format: uuid
+      responses:
+        200:
+          description: JSON contact object
+          schema:
+            $ref: '#/definitions/AuditItemList'
+        404:
+          description: contact does not exist
+  /v3/contact/{contactId}/archive:
+    post:
+      tags:
+      - contact
+      summary: Archives a contact with a reason
+      operationId: archiveContact
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: contactId
+        description: UUID of contact
+        required: true
+        type: string
+        format: uuid
+      - in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/ArchiveReason'
+      responses:
+        201:
+          description: contact archived
+        400:
+          description: input invalid
+        404:
+          description: contact is already archived or does not exist
+  /v3/contact/{contactId}/unarchive:
+    post:
+      tags:
+      - contact
+      summary: Unarchives a contact
+      operationId: unarchiveContact
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: contactId
+        description: UUID of contact
+        required: true
+        type: string
+        format: uuid
+      responses:
+        201:
+          description: contact unarchived
+        400:
+          description: input invalid
+        404:
+          description: contact is already archived or does not exist

--- a/generator/specs/paths/investment.yml
+++ b/generator/specs/paths/investment.yml
@@ -111,6 +111,30 @@
           description: item updated
         400:
           description: invalid input, object invalid
+  /v3/investment/{investmentId}/audit:
+    get:
+      tags:
+      - investment
+      summary: Get audit log
+      operationId: getInvestmentAudit
+      description: |
+        Returns the audit log for a specified investment project
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: investmentId
+        description: UUID of an investment project
+        required: true
+        type: string
+        format: uuid
+      responses:
+        200:
+          description: JSON investment object
+          schema:
+            $ref: '#/definitions/AuditItemList'
+        404:
+          description: investment project does not exist
   /v3/investment/{investmentId}/archive:
     post:
       tags:


### PR DESCRIPTION
Replaces https://github.com/uktrade/data-hub-api-spec/pull/37

* Documents the existing investment project and company audit endpoints.
* Documents the existing contact endpoints
* Removes incorrect archived param from PATCH company endpoint