### PR TITLE
[DH-783] Merge service deliveries into interactions

### DIFF
--- a/generator/specs/definitions/event_defs.yml
+++ b/generator/specs/definitions/event_defs.yml
@@ -63,6 +63,19 @@
         description: DIT UK region, required when address_country is United Kingdom
       service:
         $ref: '#/definitions/Service'
+  EventSlim:
+    type: object
+    required:
+    - id
+    - name
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: 'd290f1ee-6c54-4b01-90e6-d701748f0851'
+      name:
+        type: string
+        example: 'New York fashion webinar'
   EventList:
     type: object
     required:

--- a/generator/specs/definitions/interaction_defs.yml
+++ b/generator/specs/definitions/interaction_defs.yml
@@ -2,10 +2,10 @@
     type: object
     description: An interaction (e.g. meeting, email) between DIT and a company
     required:
+    - class
     - date
     - dit_adviser
     - dit_team
-    - interaction_type
     - investment_project
     - service
     - subject
@@ -15,6 +15,11 @@
         type: string
         format: uuid
         example: d290f1ee-6c54-4b01-90e6-d701748f0851
+      class:
+        type: string
+        enum:
+        - interaction
+        - service_delivery
       subject:
         type: string
         example: Exporting exhibition meeting
@@ -25,6 +30,8 @@
         type: string
         format: date
         example: 2020-01-01
+      communication_channel:
+        $ref: '#/definitions/InteractionCommunicationChannel'
       company:
         $ref: '#/definitions/CompanySlim'
       contact:
@@ -33,8 +40,8 @@
         $ref: '#/definitions/Adviser'
       dit_team:
         $ref: '#/definitions/TeamSlim'
-      interaction_type:
-        $ref: '#/definitions/InteractionType'
+      event:
+        $ref: '#/definitions/EventSlim'
       investment_project:
         $ref: '#/definitions/InvestmentProjectSlim'
       service:
@@ -52,9 +59,9 @@
         type: array
         items:
           $ref: '#/definitions/Interaction'
-  InteractionType:
+  InteractionCommunicationChannel:
     type: object
-    description: "Interaction type (mode of communication) metadata"
+    description: "Channel (mode of communication) metadata"
     required:
       - id
       - name

--- a/generator/specs/paths/interaction.yml
+++ b/generator/specs/paths/interaction.yml
@@ -9,6 +9,11 @@
       - application/json
       parameters:
       - in: query
+        name: class
+        description: Interaction class (interaction or service_delivery)
+        required: false
+        type: string
+      - in: query
         name: company_id
         description: UUID of a company
         default: 'd290f1ee-6c54-4b01-90e6-d701748f0851'


### PR DESCRIPTION
Makes the following field changes to interactions:

- Adds class to specify whether an interaction is an interaction or service delivery. This would've been interaction_type but since that was previously used I went for a different name to avoid conflicts.
- Renames the old interaction_type to communication_channel (would've been confusing otherwise, communication channel is what it's called in CDMS)
- Adds event (for service deliveries)