### PR TITLE
Rename interaction class to kind

### DIFF
--- a/generator/specs/definitions/interaction_defs.yml
+++ b/generator/specs/definitions/interaction_defs.yml
@@ -2,7 +2,7 @@
     type: object
     description: An interaction (e.g. meeting, email) between DIT and a company
     required:
-    - class
+    - kind
     - date
     - dit_adviser
     - dit_team
@@ -15,7 +15,7 @@
         type: string
         format: uuid
         example: d290f1ee-6c54-4b01-90e6-d701748f0851
-      class:
+      kind:
         type: string
         enum:
         - interaction

--- a/generator/specs/paths/interaction.yml
+++ b/generator/specs/paths/interaction.yml
@@ -9,8 +9,8 @@
       - application/json
       parameters:
       - in: query
-        name: class
-        description: Interaction class (interaction or service_delivery)
+        name: kind
+        description: Interaction kind (interaction or service_delivery)
         required: false
         type: string
       - in: query


### PR DESCRIPTION
Since class can be a reserved word this renames it to kind to make lives easier.