### PR TITLE
Add investment client relationship manager team and investor country

### DIFF
--- a/generator/specs/definitions/investment_defs.yml
+++ b/generator/specs/definitions/investment_defs.yml
@@ -44,6 +44,9 @@
         $ref: '#/definitions/ContactArray'
       client_relationship_manager:
         $ref: '#/definitions/Adviser'
+      client_relationship_manager_team:
+        $ref: '#/definitions/AdviserTeam'
+        description: Read-only team of the client relationship manager
       description:
         type: string
         example: 'Marriott hotels wishes to open in a new part of Manchester under-served by its existing hotels'
@@ -63,6 +66,9 @@
         $ref: '#/definitions/CompanySlim'
       investor_company:
         $ref: '#/definitions/CompanySlim'
+      investor_company_country:
+        $ref: '#/definitions/Country'
+        description: Read-only country of the investor company
       investment_type:
         $ref: '#/definitions/InvestmentType'
       name:


### PR DESCRIPTION
Adds `client_relationship_manager_team` and `investor_company_country` following the same pattern as `project_manager_team` and `project_assurance_team`